### PR TITLE
launch.sh: chmod +x bin/bash

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -328,6 +328,7 @@ main() {
     chmod +x "$PAK_DIR/bin/minui-presenter"
     chmod +x "$PAK_DIR/bin/minui-power-control"
     chmod +x "$PAK_DIR/bin/jq"
+    chmod +x "$PAK_DIR/bin/bash"
 
     allowed_platforms="tg5040"
     if ! echo "$allowed_platforms" | grep -q "$PLATFORM"; then


### PR DESCRIPTION
I'm not sure why these are being chmod'd here, but may as well add bash to the list.