### PR TITLE
launch.sh: move gamedir patching to runtime

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -451,17 +451,31 @@ main() {
         done
 
         show_message "Applying changes, please wait..." &
-        shell_scripts=$(find_shell_scripts "$ROM_DIR")
-        echo "Updating shebangs for game scripts..."
-        echo "$shell_scripts" | update_shebangs_from_list
-        echo "Updating PortMaster path for game scripts..."
-        echo "$shell_scripts" | filter_files_with_string "/roms/ports/PortMaster" | update_portmaster_path_from_list
         replace_progressor_binaries "$PORTS_DIR"
         copy_artwork
         copy_game_scripts
         process_squashfs_files "$EMU_DIR/libs"
     else
         echo "Starting PortMaster with port: $ROM_PATH"
+
+        directory="${TEMP_DATA_DIR#/}"
+        gamedir_line=$(grep '^GAMEDIR=' "$ROM_PATH")
+        eval "$gamedir_line"
+        echo "Game dir is: $GAMEDIR"
+
+        if [ -n "$GAMEDIR" ]; then
+            shell_scripts=$(find_shell_scripts "$GAMEDIR")
+            echo "Updating shebangs for game scripts..."
+            echo "$shell_scripts" | update_shebangs_from_list
+            echo "Updating PortMaster path for game scripts..."
+            echo "$shell_scripts" | filter_files_with_string "/roms/ports/PortMaster" | update_portmaster_path_from_list
+        else
+            # If we can't find the GAMEDIR to patch let's not attempt to
+            # run it, since running an unpatched Port will power down NextUI.
+            echo "No GAMEDIR found in $ROM_PATH, not executing game."
+            show_message "Patch failed, exiting..." 3
+            exit 1
+        fi
 
         nintendo_file=$(find "$USERDATA_PATH/PORTS-portmaster" -maxdepth 1 -iname "nintendo*" -type f)
         if [ -n "$nintendo_file" ]; then


### PR DESCRIPTION
Moves the game directory patching (utilizing 'find_shell_scripts') to the game initialization stage rather than Portmaster UI exit.

find_shell_scripts is currently the biggest bottleneck in my testing (makes up ~70% of the shutdown time), moving this to game initialization will improve Portmaster exit time ('Applying updates...') by a huge margin.