### PR TITLE
fix: patch samefile crash in add_port_script on new port install

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -425,6 +425,8 @@ main() {
 
     unzip_pylibs "$EMU_DIR/pylibs.zip"
     sed -i "s|/mnt/SDCARD/Roms/PORTS|$ROM_DIR|g" "$EMU_DIR/pylibs/harbourmaster/platform.py"
+    sed -i 's/if not os\.path\.samefile(port_script, target_file):/if not target_file.exists() or not os.path.samefile(port_script, target_file):/' \
+        "$EMU_DIR/pylibs/harbourmaster/platform.py"
     python3 "$PAK_DIR/src/disable_python_function.py" \
         "$EMU_DIR/pylibs/harbourmaster/platform.py" portmaster_install
 


### PR DESCRIPTION
`os.path.samefile` raises `FileNotFoundError` when the target file does not exist yet, causing PortMaster to crash after installing a port. Patch `platform.py` at launch to guard the call with a `target_file.exists()` check.

Fixes #138 