### PR TITLE
fix: patch shell scripts before execution

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -460,6 +460,14 @@ main() {
     else
         echo "Starting PortMaster with port: $ROM_PATH"
 
+        # Patch the shell script before executing the game
+        echo "Updating shebang for $ROM_PATH..."
+        update_file_shebang "$ROM_PATH"
+        echo "Updating PortMaster path for $ROM_PATH..."
+        if grep -q "/roms/ports/PortMaster" "$ROM_PATH"; then
+            echo "$ROM_PATH" | update_portmaster_path_from_list
+        fi
+
         directory="${TEMP_DATA_DIR#/}"
         gamedir_line=$(grep '^GAMEDIR=' "$ROM_PATH")
         eval "$gamedir_line"


### PR DESCRIPTION
An oversight in ec090d4f7d caused us to miss patching shell scripts, causing all games to be unable to load. This resolves that by patching the file directly before running it.