### PR TITLE
fix: game patching fails on some games with malformed GAMEDIR

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -461,6 +461,7 @@ main() {
         echo "Starting PortMaster with port: $ROM_PATH"
 
         directory="${TEMP_DATA_DIR#/}"
+        PORTDIR="/$directory/ports"
         gamedir_line=$(grep '^GAMEDIR=' "$ROM_PATH")
         eval "$gamedir_line"
         echo "Game dir is: $GAMEDIR"


### PR DESCRIPTION
We assume all Ports use `GAMEDIR=/$directory/ports/gamename`, but Znax seems to use `GAMEDIR="$PORTDIR/znax"`.

Set the PORTDIR variable so that we can eval ${GAMEDIR} for any port scripts that need it.

Fixes #139