### PR TITLE
launch.sh: comment the GAMEDIR eval

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -476,6 +476,9 @@ run_port() {
 
     directory="${TEMP_DATA_DIR#/}"
     PORTDIR="/$directory/ports"
+    # Ports declare GAMEDIR=... at the top of their script. eval is the
+    # simplest way to honor whatever quoting/expansion the port author
+    # used; the input is a trusted port script we are about to run.
     gamedir_line=$(grep -iE '^[[:space:]]*(export[[:space:]]+)?GAMEDIR=' "$ROM_PATH")
     eval "$gamedir_line"
     GAMEDIR="${GAMEDIR:-$gamedir}"


### PR DESCRIPTION
A bare eval on the output of grep is a reliable trigger for the "is this safe?" reflex. Add three lines explaining that ports declare GAMEDIR at the top of their own script, that eval honours whatever quoting/expansion the port author chose, and that the input is the trusted port script we are about to execute anyway.