### PR TITLE
ci: add shellcheck job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,20 @@ permissions:
   contents: write
 
 jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Run shellcheck
+        # --severity=error is the starting baseline. Once the existing
+        # warnings (e.g. SC2086 line 245, SC2034 line 463) are cleaned up
+        # we can ratchet up to --severity=warning.
+        run: shellcheck --severity=error launch.sh files/progressor
+
   build:
     name: build
     runs-on: ubuntu-24.04-arm


### PR DESCRIPTION
Adds a lightweight lint job that runs shellcheck against launch.sh and files/progressor on every PR and push to main. Starting baseline is --severity=error so the job is green today; once the existing warnings (SC2086, SC2034, SC2221/2222, SC3013) are cleaned up the threshold can be tightened.