### PR TITLE
launch.sh: collapse preflight command -v + chmod into a loop

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -355,24 +355,14 @@ main() {
         export PLATFORM="tg5040"
     fi
 
-    if ! command -v minui-presenter >/dev/null 2>&1; then
-        show_message "Minui-presenter not found." 3
-        exit 1
-    fi
-
-    if ! command -v minui-power-control >/dev/null 2>&1; then
-        show_message "Minui-power-control not found." 3
-        exit 1
-    fi
-
-    if ! command -v jq >/dev/null 2>&1; then
-        show_message "Jq not found." 3
-        exit 1
-    fi
-
-    chmod +x "$PAK_DIR/bin/minui-presenter"
-    chmod +x "$PAK_DIR/bin/minui-power-control"
-    chmod +x "$PAK_DIR/bin/jq"
+    required_tools="minui-presenter minui-power-control jq"
+    for tool in $required_tools; do
+        if ! command -v "$tool" >/dev/null 2>&1; then
+            show_message "$tool not found." 3
+            exit 1
+        fi
+        chmod +x "$PAK_DIR/bin/$tool"
+    done
     chmod +x "$PAK_DIR/bin/bash"
 
     allowed_platforms="tg5040"


### PR DESCRIPTION
The three command -v / show_message / exit blocks plus the matching chmod calls were structurally identical. Pull the tool list into a required_tools variable and iterate. The bash chmod stays separate because there's no command -v gate on it.

Behavior is unchanged except for the "not found" message text: "Minui-presenter not found." -> "minui-presenter not found." (and same for the other two), now matching the binary name as invoked rather than title-cased.