### PR TITLE
launch.sh: drop debug echo and simplify empty-list check

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -242,8 +242,7 @@ modify_squashfs_scripts() {
     fi
 
     shell_scripts=$(find_shell_scripts "$tmpdir")
-    echo $shell_scripts
-    if ! echo "$shell_scripts" | grep -q .; then
+    if [ -z "$shell_scripts" ]; then
         echo "No shell scripts found in $squashfs_basename"
         rm -rf "$tmpdir"
         return 0


### PR DESCRIPTION
Removes a stray unquoted "echo \$shell_scripts" that looks like a debug leftover (and would word-split / glob a list of paths if any of them contained spaces or globs).

Replaces the "echo \"\$shell_scripts\" | grep -q ." emptiness test with the direct equivalent, [ -z "\$shell_scripts" ].