### PR TITLE
fix: detect GAMEDIR when declared as lowercase or exported

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -476,7 +476,7 @@ run_port() {
 
     directory="${TEMP_DATA_DIR#/}"
     PORTDIR="/$directory/ports"
-    gamedir_line=$(grep -iE '^(export[[:space:]]+)?GAMEDIR=' "$ROM_PATH")
+    gamedir_line=$(grep -iE '^[[:space:]]*(export[[:space:]]+)?GAMEDIR=' "$ROM_PATH")
     eval "$gamedir_line"
     GAMEDIR="${GAMEDIR:-$gamedir}"
     echo "Game dir is: $GAMEDIR"

--- a/launch.sh
+++ b/launch.sh
@@ -476,8 +476,9 @@ run_port() {
 
     directory="${TEMP_DATA_DIR#/}"
     PORTDIR="/$directory/ports"
-    gamedir_line=$(grep '^GAMEDIR=' "$ROM_PATH")
+    gamedir_line=$(grep -iE '^(export[[:space:]]+)?GAMEDIR=' "$ROM_PATH")
     eval "$gamedir_line"
+    GAMEDIR="${GAMEDIR:-$gamedir}"
     echo "Game dir is: $GAMEDIR"
 
     if [ -n "$GAMEDIR" ]; then


### PR DESCRIPTION
Some PortMaster scripts (e.g. Celeste.sh) declare the game directory as `export gamedir=...` instead of `GAMEDIR=...`. The grep for the gamedir line only matched the latter, so patching bailed out with "No GAMEDIR found" and the port refused to launch.

Match case-insensitively and tolerate an optional `export` prefix, then fold the lowercase form into GAMEDIR for the downstream check.